### PR TITLE
Clarificação do guião do laboratório 2, exercício 5

### DIFF
--- a/src/02-java-avancado.md
+++ b/src/02-java-avancado.md
@@ -300,7 +300,7 @@ O ponto de partida para o exercício ilustra a comunicação entre dois programa
 4. Modificar os programas para que o servidor responda ao cliente com uma mensagem de confirmação.
 
 5. Estenda o programa com uma *thread* que conta os pedidos em *background*:
-    - Crie a nova *thread* no início da execução do método `Main`. Crie também um objeto da classe `Integer`, que deve ser passado à nova *thread* quando esta é criada. Esse objeto será um contador partilhado entre ambas as *threads*. 
+    - Crie a nova *thread* no início da execução do método `Main`. Defina a classe `Counter`, que será um contador partilhado entre ambas as *threads*. Instancie **apenas um** objeto dessa classe e passe-o à nova *thread* quando esta é criada.
     - Sempre que a *thread* principal recebe um pedido, deve incrementar o contador. Como este é partilhado, é preciso assegurar a necessária sincronização.
     - Por outro lado, programe o método `run` da nova *thread* de forma a que esta se bloqueie até que o contador atinja 
     múltiplos de 3. Sempre que tal acontece, a *thread* deve imprimir uma mensagem com o valor do contador e voltar a bloquear-se 


### PR DESCRIPTION
### Original
5. Estenda o programa com uma *thread* que conta os pedidos em *background*:
    - Crie a nova *thread* no início da execução do método `Main`. Crie também um objeto da classe `Integer`, que deve ser passado à nova *thread* quando esta é criada. Esse objeto será um contador partilhado entre ambas as *threads*. 

### Problema
Dá a entender que o objeto `Integer` deve ser partilhado sem nenhum procedimento adicional. Como a classe `Integer` é baseada no seu valor e imutável, alterações ao seu valor vão impedir que as duas _threads_ se refiram ao mesmo objeto.

### Sugestão
Dar a entender que será necessária uma classe "_wrapper_" ao inteiro, para obter o comportamento esperado. Para além disso, o enunciado original pode levar o aluno a usar sincronização em objetos baseados em valor, que é desaconselhado e pode ter comportamento indefinido. [Blog Post](https://www.javaspecialists.eu/archive/Issue299-Synchronizing-on-Value-Based-Classes.html)
Por outro lado, o enunciado original pode levar o aluno a investigar e chegar a esta conclusão por si próprio.